### PR TITLE
Accept HTTP operation as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Runs a construct or describe query and parses the response into RDF/JS Quad stre
 - `query`: The SPARQL construct or describe query as a string.
 - `user`: User for basic authentication.
 - `password`: Password for basic authentication.
+- `operation`: The HTTP operation to use ('get' | 'postUrlencoded' | 'postDirect').
 
 ### select
 
@@ -23,3 +24,4 @@ The chunk object contains key-value pairs for each variable of the select query.
 - `query`: The SPARQL select query as a string.
 - `user`: User for basic authentication.
 - `password`: Password for basic authentication.
+- `operation`: The HTTP operation to use ('get' | 'postUrlencoded' | 'postDirect').

--- a/construct.js
+++ b/construct.js
@@ -1,9 +1,9 @@
 import Client from 'sparql-http-client'
 
-function construct ({ endpoint, query, user, password }) {
+function construct ({ endpoint, query, user, password, operation }) {
   const client = new Client({ endpointUrl: endpoint, user, password })
 
-  return client.query.construct(query)
+  return client.query.construct(query, { operation })
 }
 
 export default construct

--- a/select.js
+++ b/select.js
@@ -1,10 +1,10 @@
 import readable from 'duplex-to/readable.js'
 import Client from 'sparql-http-client'
 
-async function select ({ endpoint, query, user, password }) {
+async function select ({ endpoint, query, user, password, operation }) {
   const client = new Client({ endpointUrl: endpoint, user, password })
 
-  return readable(await client.query.select(query))
+  return readable(await client.query.select(query, { operation }))
 }
 
 export default select

--- a/test/construct.test.js
+++ b/test/construct.test.js
@@ -26,7 +26,7 @@ describe('construct', () => {
     strictEqual(isWritable(result), false)
   })
 
-  it('should send a request', async () => {
+  it('should send a GET request', async () => {
     let called = false
     const endpoint = new URL('http://example.org/send-request')
     const query = 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
@@ -40,6 +40,24 @@ describe('construct', () => {
       })
 
     await getStream.array(await construct({ endpoint, query }))
+
+    strictEqual(called, true)
+  })
+
+  it('should send a POST request', async () => {
+    let called = false
+    const endpoint = new URL('http://example.org/send-request')
+    const query = 'CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
+
+    nock(endpoint.origin)
+      .post(endpoint.pathname, query)
+      .reply(200, () => {
+        called = true
+
+        return '{}'
+      })
+
+    await getStream.array(await construct({ endpoint, query, operation: 'postDirect' }))
 
     strictEqual(called, true)
   })

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -24,7 +24,7 @@ describe('select', () => {
     strictEqual(isWritable(result), false)
   })
 
-  it('should send a request', async () => {
+  it('should send a GET request', async () => {
     let called = false
     const endpoint = new URL('http://example.org/send-request')
     const query = 'SELECT * WHERE { ?s ?p ?o }'
@@ -38,6 +38,24 @@ describe('select', () => {
       })
 
     await getStream.array(await select({ endpoint, query }))
+
+    strictEqual(called, true)
+  })
+
+  it('should send a POST request', async () => {
+    let called = false
+    const endpoint = new URL('http://example.org/send-request')
+    const query = 'SELECT * WHERE { ?s ?p ?o }'
+
+    nock(endpoint.origin)
+      .post(endpoint.pathname, query)
+      .reply(200, () => {
+        called = true
+
+        return '{}'
+      })
+
+    await getStream.array(await select({ endpoint, query, operation: 'postDirect' }))
 
     strictEqual(called, true)
   })


### PR DESCRIPTION
Beeing able to optionally set the HTTP operation as parameter enables switching from GET to POST for larger queries